### PR TITLE
Add check for line begins with '\t' in _set_screen_infos

### DIFF
--- a/screenutils/screen.py
+++ b/screenutils/screen.py
@@ -157,6 +157,7 @@ class Screen(object):
             line = ""
             for l in getoutput("screen -ls").split("\n"):
                 if (
+                        l.startswith('\t') and
                         self.name in l and
                         self.name == ".".join(
                             l.split('\t')[1].split('.')[1:]) in l):


### PR DESCRIPTION
When I create a screen session with a name of 1 character, such as 'a', using this command:
s = Screen('a', True)

I get an index out of range error in this line in the code: l.split('\t')[1].split('.')[1:]) in l

This is because it is looking at the initial line "There are screens on:"

It needs to look at the lines that begin with a tab, such as: "	59984.a	(Detached)"