### PR TITLE
chore: modernize packaging and Python 3 baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install package and test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e . pytest
+
+      - name: Run tests
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,9 @@
 *.swp
 *.pyc
 ./dist/
+
+.venv/
+.pytest_cache/
+*.egg-info/
+build/
+dist/

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ Example in a python console::
    >>> s.send_commands('bash')
    >>> s.enable_logs()
    >>> s.send_commands("df")
-   >>> print next(s.logs)
+   >>> print(next(s.logs))
    df
    Filesystem           1K-blocks      Used Available Use% Mounted on
    /dev/sda6             20161172   8084052  11052980  43% /
@@ -58,11 +58,11 @@ Installation
 
 You could install screenutils from github, by doing the following::
 
-    $ pip install git+http://github.com/Christophe31/screenutils.git
+    $ python -m pip install git+http://github.com/Christophe31/screenutils.git
 
 Or by just using the packages published on Pypi, for instance with pip::
 
-    $ pip install screenutils
+    $ python -m pip install screenutils
 
 Features
 ---------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,37 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "screenutils"
+version = "0.0.1.6.2"
+description = "Library for GNU screen: create, close, list, log sessions, and inject commands."
+readme = "README.rst"
+requires-python = ">=3.8"
+license = { text = "GPL-2.0-or-later" }
+authors = [
+    { name = "Christophe Narbonne" }
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+
+[project.urls]
+Homepage = "http://github.com/Christophe31/screenutils"
+Repository = "http://github.com/Christophe31/screenutils"
+
+[tool.setuptools.packages.find]
+include = ["screenutils*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/screenutils/screen.py
+++ b/screenutils/screen.py
@@ -7,10 +7,7 @@
 
 from screenutils.errors import ScreenNotFoundError
 
-try:
-    from commands import getoutput
-except:
-    from subprocess import getoutput
+from subprocess import getoutput
 from threading import Thread
 from os import system
 from os.path import getsize

--- a/setup.py
+++ b/setup.py
@@ -1,21 +1,6 @@
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name='screenutils',
-    version='0.0.1.6.2',
-    packages=['screenutils',],
-    license='GNU Public License >=2 (ask me if you want other)',
-    author="Christophe Narbonne",
-    author_email="@Christophe31",
-    url="http://github.com/Christophe31/screenutils",
-    description =
-    "lib for gnu-screen: creates/close/list/log sessions, injects commands...",
-    classifiers = [
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 3",
-        "Intended Audience :: Developers",
-        "Topic :: Software Development :: Libraries :: Python Modules",
-    ],
-    long_description=open('README.rst').read(),
 )
 

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,7 @@
+from screenutils import Screen, ScreenNotFoundError, list_screens
+
+
+def test_public_imports_are_available():
+    assert Screen is not None
+    assert ScreenNotFoundError is not None
+    assert callable(list_screens)


### PR DESCRIPTION
## Summary

This PR establishes a modern Python 3 project baseline for screenutils.

Changes included:

- Add `pyproject.toml` with setuptools build backend.
- Declare Python `>=3.8` support.
- Add GitHub Actions CI for Python 3.8 through 3.12.
- Add a minimal pytest import test.
- Remove the Python 2 `commands.getoutput` fallback.
- Keep `setup.py` as a small setuptools compatibility shim.
- Update README examples to Python 3 syntax.
- Ignore common local build, test, and virtualenv artifacts.

## Motivation

The README currently says:

> CAUTION: this project is not maintained anymore as it's maintainer don't use it anymore
> (and switched to tmux). If you contribute a bit, you may reclaim this project.

I would like to help maintain and modernize this project. This PR is intentionally small and non-invasive: it sets up packaging, CI, and a Python 3 baseline without changing GNU screen runtime behavior.

I have follow-up modernization changes prepared separately, but I am starting with this minimal baseline PR to keep review easy.

## Validation

On my fork, this change passes CI on Python 3.8 through 3.12.

Locally verified with:

- `python -m pytest -q`
- `python -m build`
